### PR TITLE
Move Set-AzureRmContext outside of the login so it always happens

### DIFF
--- a/scripts/InstallCustomScriptExtension.ps1
+++ b/scripts/InstallCustomScriptExtension.ps1
@@ -1,4 +1,4 @@
-﻿######################################################################################################################################################
+######################################################################################################################################################
 # InstallCustomScriptExtension.ps1
 # Copyright (c) 2018 - Microsoft Corp.
 #
@@ -135,9 +135,9 @@ if ($doAzureLogin.IsPresent)
         Exit -1
 
     }
-
-    Set-AzureRmContext -SubscriptionId $subscriptionId
 }
+
+Set-AzureRmContext -SubscriptionId $subscriptionId
 
 
 Write-Host 'Finding certificate for cluster: ' $clusterFQDN '...'


### PR DESCRIPTION
Moved call to Set-AzureRmContext outside the login block because we want to make sure we are in the specified subscription regardless of our need to login